### PR TITLE
rewrite shutdown() mathod into terminate()

### DIFF
--- a/src/main/scala/com/intenthq/wikidata/App.scala
+++ b/src/main/scala/com/intenthq/wikidata/App.scala
@@ -62,7 +62,7 @@ object App {
         case Success((t, f)) => printResults(t, f)
         case Failure(tr) => println("Something went wrong")
       }
-      system.shutdown()
+      system.terminate()
     }
     0
   }


### PR DESCRIPTION
just updated the deprecated shutdown() method to terminate()

( BTW: nice work! ;-) )
