### PR TITLE
Upgrade to Akka Streams RC4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies += "com.github.scopt" %% "scopt" % "3.3.0"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.11"
-libraryDependencies += "com.typesafe.akka" %% "akka-stream-experimental" % "1.0-RC3"
+libraryDependencies += "com.typesafe.akka" %% "akka-stream-experimental" % "1.0-RC4"
 
 scalacOptions in Test ++= Seq("-Yrangepos")
 


### PR DESCRIPTION
Needed to rename `ActorFlowMaterializer` to `ActorMaterializer`.
Also, as `InputStreamSource` is now available we are using it.
