### PR TITLE
Set SBT version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7


### PR DESCRIPTION
Create project/build.properties file so that a SBT version is set. Otherwise the system's default SBT version is picked, which may not be compatible with the project's build.sbt file.
